### PR TITLE
時間割の機能追加

### DIFF
--- a/app/src/main/java/com/dryad/tomidaiapp/DataBaseDao_tt.kt
+++ b/app/src/main/java/com/dryad/tomidaiapp/DataBaseDao_tt.kt
@@ -14,4 +14,6 @@ interface DataBaseDao_tt{
     suspend fun updateTimetable(date_time: String,classname: String,classname_jp: String,classname_en: String,teacher: String,classregicode: String,classroom: String,memo: String?): Int
     @Query("SELECT classname FROM Timetable_tbl WHERE date_time = :date_time")
     suspend fun check_empty(date_time: String): String
+    @Query("SELECT classregicode FROM TIMETABLE_TBL WHERE date_time = :date_time")
+    suspend fun getClassregicode(date_time: String): String
 }

--- a/app/src/main/java/com/dryad/tomidaiapp/TimetableActivity.kt
+++ b/app/src/main/java/com/dryad/tomidaiapp/TimetableActivity.kt
@@ -3,14 +3,20 @@ package com.dryad.tomidaiapp
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.view.View
 import android.widget.Button
+import android.widget.TextView
 import androidx.core.content.ContextCompat.startActivities
 import androidx.preference.PreferenceManager
 import kotlinx.android.synthetic.main.activity_search_data.*
+import kotlinx.android.synthetic.main.activity_timetable.*
+import kotlinx.android.synthetic.main.activity_timetable_registration.*
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.BufferedReader
@@ -19,6 +25,7 @@ import java.io.InputStreamReader
 class TimetableActivity : AppCompatActivity() {
 
     var set_classnamelang = "JP"
+    var editable:Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,35 +39,83 @@ class TimetableActivity : AppCompatActivity() {
         set_classnamelang = sharedPreferences.getString("timetable_lang", "")!!
         println(set_classnamelang)
         setTimeTable()
+        if(editable){
+            edit_tt.text = "編集終了"
+        }else{
+            edit_tt.text = "編集する"
+        }
     }
 
     fun setTimeTable(){
         var id: Int = resources.getIdentifier("Mon1", "id", packageName)
         var btn: Button
+        var txt: TextView
         val launch = GlobalScope.launch {
+            val mainHandler = Handler(Looper.getMainLooper())
             AppDatabase.getDatabase_tt(applicationContext).DataBaseDao_tt().getAll().forEach {
                 Log.d("MainActivity", "${it.date_time}${it.classname_jp}${it.classname_en}")
                 /*ログに授業名吐き出すよ*/
                 if(it.classname != null){
-                    id = resources.getIdentifier(it.date_time, "id", packageName)
-                    btn = findViewById(id)
-                    if(set_classnamelang == "JP"){
-                        println(it.classname_jp)
-                        btn.text = it.classname_jp
-                    }else if(set_classnamelang == "EN"){
-                        btn.text = it.classname_en
-                        println(it.classname_en)
+                    if(it.date_time!="Mon1") { //実験的に月曜１限だけTextViewにしてるよ
+                        id = resources.getIdentifier(it.date_time, "id", packageName)
+                        btn = findViewById(id)
+                        if (set_classnamelang == "JP") {
+                            println(it.classname_jp)
+                            btn.text = it.classname_jp
+                        } else if (set_classnamelang == "EN") {
+                            btn.text = it.classname_en
+                            println(it.classname_en)
+                        }
+                    }else{
+                        id = resources.getIdentifier(it.date_time, "id", packageName)
+                        txt = findViewById(id)
+                        if (set_classnamelang == "JP") {
+                            println(it.classname_jp)
+                            mainHandler.post{ txt.text = it.classname_jp }
+                            //txt.text = it.classname_jp
+                        } else if (set_classnamelang == "EN") {
+                            txt.text = it.classname_en
+                            mainHandler.post{ txt.text = it.classname_en }
+                            //println(it.classname_en)
+                        }
                     }
                 }
             }
         }
     }
 
-    fun onButtonTapped(view: View){
+    fun onEachButtonTapped(view: View){
         val str_btn_id = resources.getResourceEntryName(view.id)//そのままだと数字の羅列で出てくるからこれで変換してるよ
         println(str_btn_id)
-        val intent = Intent(this, TimetableRegistrationActivity::class.java)
-        intent.putExtra("id", str_btn_id)
-        startActivities(arrayOf(intent))
+        if(editable){
+            val intent = Intent(this, TimetableRegistrationActivity::class.java)
+            intent.putExtra("id", str_btn_id)
+            startActivities(arrayOf(intent))
+        }else{
+            /*授業詳細がでるようにしたい*/
+            var classregicode: String
+            val launch = runBlocking {
+                classregicode = AppDatabase.getDatabase_tt(applicationContext).DataBaseDao_tt().getClassregicode(str_btn_id)
+            }
+            if(classregicode.isNotEmpty()) {
+                val intent = Intent(this, ListData::class.java)
+                intent.putExtra("SEND_DATA", classregicode)
+                startActivities(arrayOf(intent))
+            }
+        }
+    }
+
+    fun onTappedEdit(view: View){
+        println("************")
+        if(editable){
+            editable = false
+            edit_tt.text = "編集する"
+            println("editable = false")
+        }else{
+            editable = true
+            edit_tt.text = "完了"
+            println("editable = true")
+        }
+
     }
 }

--- a/app/src/main/java/com/dryad/tomidaiapp/TimetableRegistrationActivity.kt
+++ b/app/src/main/java/com/dryad/tomidaiapp/TimetableRegistrationActivity.kt
@@ -24,6 +24,7 @@ class TimetableRegistrationActivity : AppCompatActivity(), check_update_DialogFr
     var text_classname_jp = ""
     var text_classname_en = ""
 
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_timetable_registration)
@@ -178,6 +179,7 @@ class TimetableRegistrationActivity : AppCompatActivity(), check_update_DialogFr
             Log.d("result", "$result")//1だったら適切に１列更新できているはず
         }
     }
+
 
     fun onBackPressed(view: View) {
         super.onBackPressed()

--- a/app/src/main/res/layout/activity_timetable.xml
+++ b/app/src/main/res/layout/activity_timetable.xml
@@ -5,411 +5,448 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".TimetableActivity">
-
-    <TableLayout
-        android:id="@+id/container"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
 
-            <TextView
-                android:layout_width="0dp"
+        <Button
+            android:id="@+id/edit_tt"
+            android:layout_width="100dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right"
+            android:layout_weight="0.03"
+            android:onClick="onTappedEdit"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TableLayout
+            android:id="@+id/container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.97
+"
+            android:paddingBottom="20dp"
+            android:paddingHorizontal="20dp"
+
+            app:layout_constraintTop_toBottomOf="@+id/edit_tt">
+
+            <TableRow
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:clickable="false"
+                    android:gravity="center"
+                    android:text="月曜日" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:text="火曜日" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:text="水曜日" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:text="木曜日" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:text="金曜日" />
+
+            </TableRow>
+
+            <TableRow
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
+
+                <!--Button
+                    android:id="@+id/Mon1"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform"/-->
+
+                <EditText
+                    android:id="@+id/Mon1"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:clickable="false"
+                    android:cursorVisible="false"
+                    android:editable="false"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Tue1"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Wed1"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Thu1"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Fri1"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:clickable="false"
-                android:gravity="center"
-                android:text="月曜日" />
+                app:autoSizeTextType="uniform">
 
-            <TextView
-                android:layout_width="0dp"
+                <Button
+                    android:id="@+id/Mon2"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    android:textColor="#000000"
+                    app:autoSizeTextType="uniform"
+                    app:backgroundTint="#FFFFFF" />
+
+                <Button
+                    android:id="@+id/Tue2"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Wed2"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Thu2"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Fri2"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="火曜日"
-                android:gravity="center" />
+                android:layout_weight="1">
 
-            <TextView
-                android:layout_width="0dp"
+                <Button
+                    android:id="@+id/Mon3"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Tue3"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Wed3"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Thu3"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Fri3"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="水曜日"
-                android:gravity="center" />
+                android:layout_weight="1">
 
-            <TextView
-                android:layout_width="0dp"
+                <Button
+                    android:id="@+id/Mon4"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Tue4"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Wed4"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Thu4"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Fri4"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="木曜日"
-                android:gravity="center" />
+                android:layout_weight="1">
 
-            <TextView
-                android:layout_width="0dp"
+                <Button
+                    android:id="@+id/Mon5"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Tue5"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Wed5"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Thu5"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+
+                <Button
+                    android:id="@+id/Fri5"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="金曜日"
-                android:gravity="center" />
+                android:layout_weight="1">
 
-        </TableRow>
+                <Button
+                    android:id="@+id/Mon6"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
 
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1">
+                <Button
+                    android:id="@+id/Tue6"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
 
-            <Button
-                android:id="@+id/Mon1"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
+                <Button
+                    android:id="@+id/Wed6"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
 
-            <Button
-                android:id="@+id/Tue1"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
+                <Button
+                    android:id="@+id/Thu6"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
 
-            <Button
-                android:id="@+id/Wed1"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
+                <Button
+                    android:id="@+id/Fri6"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+            </TableRow>
 
-            <Button
-                android:id="@+id/Thu1"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
+            <TableRow
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
 
-            <Button
-                android:id="@+id/Fri1"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-        </TableRow>
+                <Button
+                    android:id="@+id/Mon7"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
 
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            app:autoSizeTextType="uniform">
+                <Button
+                    android:id="@+id/Tue7"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
 
-            <Button
-                android:id="@+id/Mon2"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
+                <Button
+                    android:id="@+id/Wed7"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
 
-            <Button
-                android:id="@+id/Tue2"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
+                <Button
+                    android:id="@+id/Thu7"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
 
-            <Button
-                android:id="@+id/Wed2"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Thu2"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Fri2"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-        </TableRow>
-
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1">
-
-            <Button
-                android:id="@+id/Mon3"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Tue3"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Wed3"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Thu3"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Fri3"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-        </TableRow>
-
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1">
-
-            <Button
-                android:id="@+id/Mon4"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Tue4"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Wed4"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Thu4"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Fri4"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-        </TableRow>
-
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1">
-
-            <Button
-                android:id="@+id/Mon5"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Tue5"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Wed5"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Thu5"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Fri5"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-        </TableRow>
-
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1">
-
-            <Button
-                android:id="@+id/Mon6"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Tue6"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Wed6"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Thu6"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Fri6"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-        </TableRow>
-
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1">
-
-            <Button
-                android:id="@+id/Mon7"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Tue7"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Wed7"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Thu7"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-
-            <Button
-                android:id="@+id/Fri7"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:onClick="onButtonTapped"
-                android:text="未登録"
-                app:autoSizeTextType="uniform"/>
-        </TableRow>
+                <Button
+                    android:id="@+id/Fri7"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:onClick="onEachButtonTapped"
+                    android:text="未登録"
+                    app:autoSizeTextType="uniform" />
+            </TableRow>
 
     </TableLayout>
+
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -8,6 +8,7 @@
 
     <item name="input_to_search" type="id"/>
 
+    <item name="editt_tt" type="id"/>
 
     <item name="Mon1" type="id"/>
     <item name="Mon2" type="id"/>


### PR DESCRIPTION
編集ボタンを追加しました
編集するが押された状態で時間割をタップするとこれまで通りの編集画面に、押されていない状態でタップするとカスタムアダプターでシラバスの内容を表示するように変更しました
表示比較のため時間割の一部レイアウトを変更しています。